### PR TITLE
Settings: Make find fingerprint look great again

### DIFF
--- a/res/layout/fingerprint_enroll_find_sensor_graphic.xml
+++ b/res/layout/fingerprint_enroll_find_sensor_graphic.xml
@@ -17,13 +17,14 @@
 
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="@dimen/fingerprint_find_sensor_graphic_size"
-    android:layout_height="@dimen/fingerprint_find_sensor_graphic_size">
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/fingerprint_find_sensor_padding_top">
 
     <ImageView
         android:id="@+id/fingerprint_sensor_location"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:contentDescription="@string/security_settings_fingerprint_enroll_find_sensor_content_description"
         android:src="@drawable/fingerprint_sensor_location"
         android:scaleType="centerInside"/>
@@ -31,7 +32,7 @@
     <ImageView
         android:id="@+id/fingerprint_sensor_location_front_overlay"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:contentDescription="@string/security_settings_fingerprint_enroll_find_sensor_content_description"
         android:src="@drawable/fingerprint_sensor_location_front_overlay"
         android:scaleType="centerInside"

--- a/res/values/lineage_dimens.xml
+++ b/res/values/lineage_dimens.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2019 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <!-- Fingerprint -->
+    <dimen name="fingerprint_find_sensor_padding_top">16dp</dimen>
+</resources>

--- a/src/com/android/settings/fingerprint/FingerprintLocationAnimationView.java
+++ b/src/com/android/settings/fingerprint/FingerprintLocationAnimationView.java
@@ -28,6 +28,7 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.animation.AnimationUtils;
 import android.view.animation.Interpolator;
+import android.widget.ImageView;
 
 import com.android.settings.R;
 import com.android.settings.Utils;
@@ -53,6 +54,7 @@ public class FingerprintLocationAnimationView extends View implements
     private float mPulseRadius;
     private ValueAnimator mRadiusAnimator;
     private ValueAnimator mAlphaAnimator;
+    private ImageView mOverlayImage;
 
     public FingerprintLocationAnimationView(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
@@ -92,7 +94,11 @@ public class FingerprintLocationAnimationView extends View implements
     }
 
     private float getCenterY() {
-        return getHeight() * mFractionCenterY;
+        if (mOverlayImage == null) {
+            mOverlayImage = (ImageView) getRootView().findViewById(
+                    R.id.fingerprint_sensor_location);
+        }
+        return mOverlayImage.getHeight() * mFractionCenterY;
     }
 
     @Override


### PR DESCRIPTION
* The current logic places the animation based on the size of
  the whole overlay instead of the image, which is a fixed-size
  png
* Get the size of the image instead and place the dot relative
  to it
* Also use "wrap_content" and add a padding to the top so the
  distance to the text is a fixed thing, not depending on how
  much space relative to the wanted space it actually takes

* Preview: https://imgur.com/a/XanJ2aP

Change-Id: I2bd08cee1abd1c6bad78ca1efc2189e573ded3cc