### PR TITLE
SystemUI: Bring back lockscreen tuner (2/2)

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -368,4 +368,7 @@
     <!-- Whether the keyguard will directly show the lock entry -->
     <string name="directly_show_lock">Direct unlock</string>
     <string name="directly_show_lock_summary">Skip the swipe to unlock screen and immediately begin key entry</string>
+
+    <!-- Jump to lockscreen tuner to let user change lockscreen shortcuts -->
+    <string name="open_lockscreen_tuner">Change shortcuts</string>
 </resources>

--- a/res/xml/security_lockscreen_settings.xml
+++ b/res/xml/security_lockscreen_settings.xml
@@ -50,6 +50,12 @@
         android:summary="@string/lockdown_settings_summary"
         settings:controller="com.android.settings.security.LockdownButtonPreferenceController"/>
 
+    <PreferenceScreen
+        android:key="lockscreen_tuner"
+        android:title="@string/open_lockscreen_tuner">
+        <intent android:action="com.android.settings.action.LOCK_SCREEN_TUNER" />
+    </PreferenceScreen>
+
     <!-- Work profile settings are at the bottom with high order value to avoid users thinking that
          any of the above settings (including dynamic) are specific to the work profile. -->
     <PreferenceCategory


### PR DESCRIPTION
* Enables us to change lockscreen shortcuts, but they will be disabled as default.
  (Leaving SystemUI/config.xml as it is makes this possible.)
* It will be located under Settings > Security & Location > Lock screen preferences

Change-Id: I2c5fe80d1d25c9b20376331ebdad850bdb640eb2
Signed-off-by: eray orçunus <erayorcunus@gmail.com>